### PR TITLE
use parent dependencies for junit, airlift and commons-io

### DIFF
--- a/taverna-language-commandline/pom.xml
+++ b/taverna-language-commandline/pom.xml
@@ -96,7 +96,6 @@
         <dependency>
 	    	<groupId>io.airlift</groupId>
 	    	<artifactId>airline</artifactId>
-	    	<version>0.7</version>
 		</dependency>
 	
         

--- a/taverna-scufl2-examples/pom.xml
+++ b/taverna-scufl2-examples/pom.xml
@@ -62,13 +62,11 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/taverna-scufl2-wfdesc/pom.xml
+++ b/taverna-scufl2-wfdesc/pom.xml
@@ -271,7 +271,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.4</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
@@ -325,7 +324,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.1</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Use taverna-maven-parent dependency version numbers rather than hardcoded for junit, airlift and commons-io in taverna-language-commandline, taverna-scufl2-examples and taverna-scufl2-wfdesc.