### PR TITLE
Update JavaDoc in Processor.java - rm @value tags

### DIFF
--- a/taverna-scufl2-api/src/main/java/org/apache/taverna/scufl2/api/core/Processor.java
+++ b/taverna-scufl2-api/src/main/java/org/apache/taverna/scufl2/api/core/Processor.java
@@ -56,8 +56,8 @@ import org.apache.taverna.scufl2.api.profiles.Profile;
  * execution details such as retries or parallel jobs.
  * <p>
  * The {@link #getType()} of a Processor is normally fixed to the value given by
- * {@value #PROCESSOR_TYPE}. The configuration of a processor should
- * correspondingly be of the type given by the constant {@value #CONFIG_TYPE}.
+ * PROCESSOR_TYPE. The configuration of a processor should
+ * correspondingly be of the type given by the constant CONFIG_TYPE.
  * <p>
  * The default (implied) configuration of a Processor is as of Taverna 3.0 alpha
  * 2:


### PR DESCRIPTION
Changed two statements to remove @value tag
and use just field names. 
The @value tags are not working. As a result the getType()
Javadoc statements are incomplete, rendering as, 
"...the value given by ." and 
"...the type given by the constant ."
Problem may be caused because the fields are
not literal values. 
(Ref: http://stackoverflow.com/questions/19807696/how-to-use-value-tag-in-javadoc)