### PR TITLE
Fixed typo in dependency and updated version

### DIFF
--- a/taverna-robundle/README.md
+++ b/taverna-robundle/README.md
@@ -26,7 +26,7 @@ If you use [Maven 3](http://maven.apache.org/), then add to your `pom.xml`:
     <dependency>
         <groupId>org.apache.taverna.language</groupId>
         <artifactId>taverna-robundle</artifactId>
-        <version>>0.15.0-incubating</version>
+        <version>0.15.1-incubating</version>
     </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
The dependency has a `>` too much. Took me some time to figure out after copy-pasting.
Also 0.15.1 is available.
The best
Matthias