### PR TITLE
TAVERNA-1011 Add DataBundles.resolve() and DataBundles.resolveAsStream()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	</parent>
 	<groupId>org.apache.taverna.language</groupId>
 	<artifactId>apache-taverna-language</artifactId>
-	<version>0.15.2-incubating-SNAPSHOT</version>
+	<version>0.16.0-incubating-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Apache Taverna Language APIs (Scufl2, Databundle)</name>

--- a/taverna-baclava-language/pom.xml
+++ b/taverna-baclava-language/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
   <artifactId>taverna-baclava-language</artifactId>
   <name>Apache Taverna Baclava support</name>

--- a/taverna-databundle/pom.xml
+++ b/taverna-databundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       	<groupId>org.apache.taverna.language</groupId>
       	<artifactId>apache-taverna-language</artifactId>
-      	<version>0.15.2-incubating-SNAPSHOT</version>
+      	<version>0.16.0-incubating-SNAPSHOT</version>
     </parent>
     <artifactId>taverna-databundle</artifactId>
     <name>Apache Taverna Databundle API</name>

--- a/taverna-databundle/src/main/java/org/apache/taverna/databundle/DataBundles.java
+++ b/taverna-databundle/src/main/java/org/apache/taverna/databundle/DataBundles.java
@@ -443,7 +443,7 @@ public class DataBundles extends Bundles {
 	/**
 	 * Deeply resolve a {@link Path} to JVM objects.
 	 * <p>
-	 * This method is intended for use with a particular input/output port from 
+	 * This method is intended for used with a particular input/output port from 
 	 * {@link #getPorts(Path)} or {@link #getPort(Path, String)}.
 	 * <p>
 	 * If the path is <code>null</code> or {@link #isMissing(Path)},
@@ -451,8 +451,8 @@ public class DataBundles extends Bundles {
 	 * <p>
 	 * If the path {@link #isValue(Path)}, its {@link #getStringValue(Path)} is
 	 * returned (assuming an UTF-8 encoding). NOTE: Binary formats (e.g. PNG)
-	 * will NOT be represented correctly as such a String and should be read
-	 * directly with
+	 * will NOT be represented correctly read as UTF-8 String and should 
+	 * instead be read directly with
 	 * {@link Files#newInputStream(Path, java.nio.file.OpenOption...)}.
 	 * <p>
 	 * If the path {@link #isError(Path)}, the corresponding

--- a/taverna-databundle/src/main/java/org/apache/taverna/databundle/DataBundles.java
+++ b/taverna-databundle/src/main/java/org/apache/taverna/databundle/DataBundles.java
@@ -702,7 +702,7 @@ public class DataBundles extends Bundles {
 				return Files.walk(path)
 						// avoid re-recursion
 						.filter(p -> !Files.isDirectory(p)) 
-						.flatMap(p -> resolveItemAsStream(path, type, options));
+						.flatMap(p -> resolveItemAsStream(p, type, options));
 			} catch (IOException e) {
 				throw new UncheckedIOException(e);
 			}

--- a/taverna-databundle/src/main/java/org/apache/taverna/databundle/ErrorDocument.java
+++ b/taverna-databundle/src/main/java/org/apache/taverna/databundle/ErrorDocument.java
@@ -59,4 +59,11 @@ public class ErrorDocument {
 			trace = "";
 		this.trace = trace;
 	}
+	
+	@Override
+	public String toString() {
+		return "Error: " + getMessage() + "\n" + trace;
+		// TODO: also include the causedBy paths?
+	}
+	
 }

--- a/taverna-databundle/src/test/java/org/apache/taverna/databundle/TestDataBundles.java
+++ b/taverna-databundle/src/test/java/org/apache/taverna/databundle/TestDataBundles.java
@@ -21,7 +21,11 @@ package org.apache.taverna.databundle;
 */
 
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,6 +33,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -40,8 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.taverna.databundle.DataBundles;
-import org.apache.taverna.databundle.ErrorDocument;
 import org.apache.taverna.robundle.Bundle;
 import org.apache.taverna.scufl2.api.container.WorkflowBundle;
 import org.apache.taverna.scufl2.api.io.WorkflowBundleIO;
@@ -568,9 +571,26 @@ public class TestDataBundles {
     }    
     
     @Test
-    public void resolveBreaksOnBinaries() throws Exception {
+    public void resolveBinariesKindOf() throws Exception {
     	Path inputs = DataBundles.getInputs(dataBundle);
 		Path list = DataBundles.getPort(inputs, "in1");
+		Path item = DataBundles.newListItem(list);
+
+		byte[] bytes = new byte[] { 
+				// Those lovely lower bytes who don't work well in UTF-8
+				0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31, 
+				// and some higher ones for fun
+				-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,
+				-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31
+		};
+		Files.write(item, bytes);
+		List resolved = (List)DataBundles.resolve(list);
+		
+		// The below will always fail as several of the above bytes are not parsed as valid UTF-8
+		// but instead be substituted with replacement characters. 
+		
+		//assertArrayEquals(bytes, ((String)resolved.get(0)).getBytes(StandardCharsets.UTF_8));
+		
     }
     
     @Test

--- a/taverna-robundle/pom.xml
+++ b/taverna-robundle/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-robundle</artifactId>
 	<name>Apache Taverna RO Bundle API</name>

--- a/taverna-scufl2-annotation/pom.xml
+++ b/taverna-scufl2-annotation/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-scufl2-annotation</artifactId>
 	<packaging>bundle</packaging>

--- a/taverna-scufl2-api/pom.xml
+++ b/taverna-scufl2-api/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-scufl2-api</artifactId>
 	<packaging>bundle</packaging>

--- a/taverna-scufl2-examples/pom.xml
+++ b/taverna-scufl2-examples/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-scufl2-examples</artifactId>
 	<packaging>bundle</packaging>

--- a/taverna-scufl2-integration-tests/pom.xml
+++ b/taverna-scufl2-integration-tests/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-scufl2-integration-tests</artifactId>
 	<name>Apache Taverna Scufl 2 integration tests</name>

--- a/taverna-scufl2-schemas/pom.xml
+++ b/taverna-scufl2-schemas/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-scufl2-schemas</artifactId>
 	<packaging>bundle</packaging>

--- a/taverna-scufl2-scufl/pom.xml
+++ b/taverna-scufl2-scufl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.taverna.language</groupId>
     <artifactId>apache-taverna-language</artifactId>
-    <version>0.15.2-incubating-SNAPSHOT</version>
+    <version>0.16.0-incubating-SNAPSHOT</version>
   </parent>
   <artifactId>taverna-scufl2-scufl</artifactId>
   <packaging>bundle</packaging>

--- a/taverna-scufl2-t2flow/pom.xml
+++ b/taverna-scufl2-t2flow/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-scufl2-t2flow</artifactId>
 	<packaging>bundle</packaging>

--- a/taverna-scufl2-ucfpackage/pom.xml
+++ b/taverna-scufl2-ucfpackage/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-scufl2-ucfpackage</artifactId>
 	<packaging>bundle</packaging>

--- a/taverna-scufl2-wfbundle/pom.xml
+++ b/taverna-scufl2-wfbundle/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-scufl2-wfbundle</artifactId>
 	<packaging>bundle</packaging>

--- a/taverna-scufl2-wfdesc/pom.xml
+++ b/taverna-scufl2-wfdesc/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.apache.taverna.language</groupId>
 		<artifactId>apache-taverna-language</artifactId>
-		<version>0.15.2-incubating-SNAPSHOT</version>
+		<version>0.16.0-incubating-SNAPSHOT</version>
 	</parent>
 	<artifactId>taverna-scufl2-wfdesc</artifactId>
 	<packaging>bundle</packaging>

--- a/taverna-tavlang-tool/pom.xml
+++ b/taverna-tavlang-tool/pom.xml
@@ -20,7 +20,7 @@
     <parent>
       	<groupId>org.apache.taverna.language</groupId>
       	<artifactId>apache-taverna-language</artifactId>
-      	<version>0.15.2-incubating-SNAPSHOT</version>
+      	<version>0.16.0-incubating-SNAPSHOT</version>
     </parent>
     <artifactId>taverna-tavlang-tool</artifactId>
     <name>Apache Taverna tavlang tool</name>


### PR DESCRIPTION
As suggested in [TAVERNA-1011](https://issues.apache.org/jira/browse/TAVERNA-1011):

Adds two methods: 
* [DataBundles.resolve()](https://github.com/stain/incubator-taverna-language/blob/databundle-resolve/taverna-databundle/src/main/java/org/apache/taverna/databundle/DataBundles.java#L488)
* [DataBundles.resolveAsStream()](https://github.com/stain/incubator-taverna-language/blob/databundle-resolve/taverna-databundle/src/main/java/org/apache/taverna/databundle/DataBundles.java#L656)

See also the unit tests:
https://github.com/stain/incubator-taverna-language/blob/databundle-resolve/taverna-databundle/src/test/java/org/apache/taverna/databundle/TestDataBundles.java#L531


Perhaps a companion method would be .register(List) ? 

