### PR TITLE
TAVERNA-1027: Use file:/// instead of app://{uuid}/ as base

### DIFF
--- a/taverna-robundle/src/test/java/org/apache/taverna/robundle/manifest/TestRDFToManifest.java
+++ b/taverna-robundle/src/test/java/org/apache/taverna/robundle/manifest/TestRDFToManifest.java
@@ -22,7 +22,6 @@ package org.apache.taverna.robundle.manifest;
 
 import static org.junit.Assert.assertNotNull;
 
-import java.net.URL;
 import java.util.Map;
 
 import org.junit.Test;
@@ -39,7 +38,7 @@ public class TestRDFToManifest {
 		// RDFToManifest.makeBaseURI(); // trigger static{} block
 		@SuppressWarnings("unchecked")
 		Map<String, Object> context = (Map<String, Object>) new DocumentLoader()
-				.fromURL(new URL(CONTEXT));
+				.loadDocument(CONTEXT);
 		// FIXME: jsonld-java 0.3 and later uses DocumentLoader instead of
 		// JSONUtils
 		// Map<String, Object> context = (Map<String, Object>)

--- a/taverna-robundle/src/test/java/org/apache/taverna/robundle/manifest/TestRDFToManifest.java
+++ b/taverna-robundle/src/test/java/org/apache/taverna/robundle/manifest/TestRDFToManifest.java
@@ -38,7 +38,7 @@ public class TestRDFToManifest {
 		// RDFToManifest.makeBaseURI(); // trigger static{} block
 		@SuppressWarnings("unchecked")
 		Map<String, Object> context = (Map<String, Object>) new DocumentLoader()
-				.loadDocument(CONTEXT);
+				.loadDocument(CONTEXT).getDocument();
 		// FIXME: jsonld-java 0.3 and later uses DocumentLoader instead of
 		// JSONUtils
 		// Map<String, Object> context = (Map<String, Object>)


### PR DESCRIPTION
This fixes [TAVERNA-1027](https://issues.apache.org/jira/browse/TAVERNA-1027) for COMBINE archive.

It does not seem like JSON-LD parsing of the .ro/manifest.json fails similarly although that also uses the app://{uuid}/ base.