### PR TITLE
Cwlparser

### DIFF
--- a/taverna-scufl2-cwl/pom.xml
+++ b/taverna-scufl2-cwl/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.taverna.language</groupId>
+    <artifactId>apache-taverna-language</artifactId>
+    <version>0.16.0-incubating-SNAPSHOT</version>
+  </parent>
+  <artifactId>taverna-scufl2-cwl</artifactId>
+  <packaging>bundle</packaging>
+  <name>Apache Taverna Scufl 2 CWL parser</name>
+  <description>Parser for .cwl file format</description>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>taverna-scufl2-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons.io.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/taverna-scufl2-cwl/pom.xml
+++ b/taverna-scufl2-cwl/pom.xml
@@ -27,6 +27,7 @@
   <name>Apache Taverna Scufl 2 CWL parser</name>
   <description>Parser for .cwl file format</description>
   <dependencies>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>taverna-scufl2-api</artifactId>
@@ -39,5 +40,18 @@
       <version>${commons.io.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.17</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/CWLParser.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/CWLParser.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.taverna.scufl2.cwl;
+
+import java.util.*;
+
+import org.apache.taverna.scufl2.api.core.Workflow;
+import org.apache.taverna.scufl2.api.core.Processor;
+
+import org.apache.taverna.scufl2.api.port.InputWorkflowPort;
+import org.apache.taverna.scufl2.api.port.OutputWorkflowPort;
+import org.apache.taverna.scufl2.api.port.InputProcessorPort;
+import org.apache.taverna.scufl2.api.port.OutputProcessorPort;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class CWLParser {
+
+    private JsonNode cwlFile;
+    private YAMLHelper yamlHelper;
+
+    public CWLParser(JsonNode cwlFile) {
+        this.cwlFile = cwlFile;
+        this.yamlHelper = new YAMLHelper();
+    }
+
+    public Set<Step> parseSteps() {
+        return yamlHelper.processSteps(cwlFile);
+    }
+
+    public Set<PortDetail> parseInputs() {
+        Map<String, PortDetail> inputs = yamlHelper.processInputDetails(cwlFile);
+        Map<String, Integer> inputDepths = yamlHelper.processInputDepths(cwlFile);
+
+        if(inputs == null || inputDepths == null) {
+            return null;
+        }
+        Set<PortDetail> result = new HashSet<PortDetail>();
+        for(String id: inputs.keySet()) {
+            PortDetail port = inputs.get(id);
+            port.setId(id);
+            int depth = inputDepths.get(id);
+            port.setDepth(depth);
+            result.add(port);
+        }
+
+        return result;
+    }
+
+    public Set<PortDetail> parseOutputs() {
+        Map<String, PortDetail> inputs = yamlHelper.processOutputDetails(cwlFile);
+
+        if(inputs == null) {
+            return null;
+        }
+        Set<PortDetail> result = new HashSet<PortDetail>();
+        for(String id: inputs.keySet()) {
+            PortDetail port = inputs.get(id);
+            result.add(port);
+        }
+
+        return result;
+    }
+
+}

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/CWLParser.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/CWLParser.java
@@ -18,7 +18,9 @@
  */
 package org.apache.taverna.scufl2.cwl;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.apache.taverna.scufl2.api.core.Workflow;
 import org.apache.taverna.scufl2.api.core.Processor;

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/Converter.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/Converter.java
@@ -30,26 +30,25 @@ import org.apache.taverna.scufl2.api.port.OutputProcessorPort;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-public class Parser {
+public class Converter {
 
-    private JsonNode cwlFile;
-    private YAMLHelper yamlHelper;
-    private Workflow workflow;
+    public Converter() {
 
-    public Parser(JsonNode cwlFile) {
-        this.cwlFile = cwlFile;
-        this.yamlHelper = new YAMLHelper();
-        this.workflow = new Workflow();
-        this.workflow.setInputPorts(parseInputs());
-        this.workflow.setOutputPorts(parseOutputs());
     }
 
-    public Workflow getWorkflow() {
-        return this.workflow;
+    public InputWorkflowPort convertInputWorkflowPort(PortDetail input) {
+        InputWorkflowPort port = new InputWorkflowPort();
+        port.setName(input.getId());
+        port.setDepth(input.getDepth());
+
+        return port;
     }
 
-    public Set<Step> parseSteps() {
-        return yamlHelper.processSteps(cwlFile);
+    public OutputWorkflowPort convertOutputWorkflowPort(PortDetail input) {
+        OutputWorkflowPort port = new OutputWorkflowPort();
+        port.setName(input.getId());
+
+        return port;
     }
 
     public Processor convertStepToProcessor(Step step) {
@@ -73,42 +72,4 @@ public class Parser {
 
         return processor;
     }
-
-    public Set<InputWorkflowPort> parseInputs() {
-        Map<String, PortDetail> inputs = yamlHelper.processInputDetails(cwlFile);
-        Map<String, Integer> inputDepths = yamlHelper.processInputDepths(cwlFile);
-
-        if(inputs == null || inputDepths == null) {
-            return null;
-        }
-        Set<InputWorkflowPort> result = new HashSet<InputWorkflowPort>();
-        for(String id: inputs.keySet()) {
-            PortDetail detail = inputs.get(id);
-            int depth = inputDepths.get(id);
-            InputWorkflowPort port = new InputWorkflowPort();
-            port.setName(id);
-            port.setDepth(depth);
-            result.add(port);
-        }
-
-        return result;
-    }
-
-    public Set<OutputWorkflowPort> parseOutputs() {
-        Map<String, PortDetail> inputs = yamlHelper.processOutputDetails(cwlFile);
-
-        if(inputs == null) {
-            return null;
-        }
-        Set<OutputWorkflowPort> result = new HashSet<OutputWorkflowPort>();
-        for(String id: inputs.keySet()) {
-            PortDetail detail = inputs.get(id);
-            OutputWorkflowPort port = new OutputWorkflowPort();
-            port.setName(id);
-            result.add(port);
-        }
-
-        return result;
-    }
-
 }

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/Converter.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/Converter.java
@@ -18,7 +18,8 @@
  */
 package org.apache.taverna.scufl2.cwl;
 
-import java.util.*;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.apache.taverna.scufl2.api.core.Workflow;
 import org.apache.taverna.scufl2.api.core.Processor;

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/Parser.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/Parser.java
@@ -6,6 +6,44 @@ import java.util.HashMap;
 import java.util.Map;
 
 
+
+class InputField {
+
+    public String key;
+    public String type;
+    public int position;
+    public String prefix;
+
+    public InputField(String _key) {
+        key = _key;
+        type = "";
+        position = -1;
+        prefix = "";
+    }
+
+    public InputField(String _key, String _type) {
+        key = _key;
+        type = _type;
+        position = -1;
+        prefix = "";
+    }
+
+    public InputField(String _key, String _type, int pos) {
+        key = _key;
+        type = _type;
+        position = pos;
+        prefix = "";
+    }
+
+    public InputField(String _key, String _type, int pos, String _prefix) {
+        key = _key;
+        type = _type;
+        position = pos;
+        prefix = _prefix;
+    }
+}
+
+
 public class Parser {
 
     private String yamlLine;
@@ -37,5 +75,46 @@ public class Parser {
         } catch (IOException e) {
             System.err.println("Parser init error: " + e );
         }
+    }
+
+
+
+
+    private int getNextLineIndex(int index) {
+        index++;
+
+        while(yamlFile.get(index).equals("")) {
+            index++;
+        }
+
+        return index;
+    }
+
+    public static int getDepth(String line) {
+        int count = 0;
+        int idx = 0;
+        while(idx < line.length()) {
+            if(line.charAt(idx) != ' ') {
+                break;
+            }
+            count++;
+            idx++;
+        }
+        assert count % 2 == 0;
+        return count / 2;
+    }
+
+    public static String getKeyFromLine(String line) {
+        int commaIndex = line.indexOf(':');
+        assert commaIndex != -1;
+
+        return line.substring(0, commaIndex).trim();
+    }
+
+    public static String getValueFromLine(String line) {
+        int commaIndex = line.indexOf(':');
+        assert commaIndex != -1;
+
+        return line.substring(commaIndex + 1).trim();
     }
 }

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/Parser.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/Parser.java
@@ -1,0 +1,41 @@
+package org.apache.taverna.scufl2.cwl;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class Parser {
+
+    private String yamlLine;
+    private int fileLength;
+
+    private Map<Integer, String> yamlFile = null;
+
+    public Parser(File file) {
+        int counter = 0;
+
+        yamlFile = new HashMap<>();
+
+        FileReader yamlFileDescriptor = null;
+
+
+        try {
+            yamlFileDescriptor = new FileReader(file);
+            BufferedReader bufferedReader = new BufferedReader(yamlFileDescriptor);
+            String parent = null;
+            int parentDepth = 0;
+            while((yamlLine = bufferedReader.readLine()) != null) {
+
+                yamlFile.put(counter, yamlLine);
+                counter = counter + 1;
+            }
+
+            bufferedReader.close();
+            fileLength = counter;
+        } catch (IOException e) {
+            System.err.println("Parser init error: " + e );
+        }
+    }
+}

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/WorkflowParser.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/WorkflowParser.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.taverna.scufl2.cwl;
+
+import java.io.*;
+import java.util.*;
+
+import java.lang.NullPointerException;
+
+import org.yaml.snakeyaml.Yaml;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+import org.apache.taverna.scufl2.api.core.Workflow;
+import org.apache.taverna.scufl2.api.core.Processor;
+import org.apache.taverna.scufl2.api.core.DataLink;
+
+import org.apache.taverna.scufl2.api.port.InputWorkflowPort;
+import org.apache.taverna.scufl2.api.port.OutputWorkflowPort;
+import org.apache.taverna.scufl2.api.port.InputProcessorPort;
+import org.apache.taverna.scufl2.api.port.OutputProcessorPort;
+import org.apache.taverna.scufl2.api.port.SenderPort;
+import org.apache.taverna.scufl2.api.port.ReceiverPort;
+import org.apache.taverna.scufl2.api.container.WorkflowBundle;
+
+import org.apache.taverna.scufl2.api.io.WorkflowBundleIO;
+import org.apache.taverna.scufl2.api.io.WriterException;
+
+public class WorkflowParser {
+
+    private static final String FILE_NAME = "/hello_world.cwl";
+    private CWLParser cwlParser;
+    private Converter converter;
+
+    private Map<String, InputWorkflowPort> workflowInputs;
+    private Map<String, OutputWorkflowPort> workflowOutputs;
+    private Map<String, Processor> workflowProcessors;
+    private Map<String, InputProcessorPort> processorInputs;
+    private Map<String, OutputProcessorPort> processorOutputs;
+    private Set<DataLink> dataLinks;
+
+    public WorkflowParser() {
+        Yaml reader = new Yaml();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode cwlFile = mapper.valueToTree(reader.load(WorkflowParser.class.getResourceAsStream(FILE_NAME)));
+        this.cwlParser = new CWLParser(cwlFile);
+        this.converter = new Converter();
+    }
+
+    public WorkflowParser(JsonNode cwlFile) {
+        this.cwlParser = new CWLParser(cwlFile);
+        this.converter = new Converter();
+        workflowInputs = new HashMap<>();
+        workflowOutputs = new HashMap<>();
+        workflowProcessors = new HashMap<>();
+        processorInputs = new HashMap<>();
+        processorOutputs = new HashMap<>();
+        dataLinks = new HashSet<DataLink>();
+    }
+
+    public Workflow buildWorkflow() {
+        parseInputs();
+        parseOutputs();
+        Set<Step> cwlSteps = cwlParser.parseSteps();
+        parseProcessors(cwlSteps);
+        parseDataLinks(cwlSteps);
+
+        Workflow workflow = new Workflow();
+        Set<InputWorkflowPort> inputs = new HashSet<>(workflowInputs.values());
+        Set<OutputWorkflowPort> outputs = new HashSet<>(workflowOutputs.values());
+        Set<Processor> processors = new HashSet<>(workflowProcessors.values());
+
+        workflow.setInputPorts(inputs);
+        workflow.setOutputPorts(outputs);
+        workflow.setProcessors(processors);
+        workflow.setDataLinks(dataLinks);
+
+//        writeWorkflowToFile(workflow);
+
+        return workflow;
+    }
+
+    public void writeWorkflowToFile(Workflow workflow) {
+        try {
+            WorkflowBundleIO io = new WorkflowBundleIO();
+            File scufl2File = new File("workflow.wfbundle");
+            WorkflowBundle bundle = io.createBundle();
+            Set<Workflow> workflowSet = new HashSet<>();
+            workflowSet.add(workflow);
+            bundle.setWorkflows(workflowSet);
+            bundle.setMainWorkflow(workflow);
+            io.writeBundle(bundle, scufl2File, "application/vnd.taverna.scufl2.workflow-bundle");
+        } catch(WriterException e) {
+            System.out.println("Exception writing the workflow bundle");
+        } catch(IOException e) {
+            System.out.println("IOException");
+        }
+    }
+
+    public void parseInputs() {
+        Set<PortDetail> cwlInputs = cwlParser.parseInputs();
+        if(cwlInputs != null) {
+            for (PortDetail port : cwlInputs) {
+                String portId = port.getId();
+                InputWorkflowPort workflowPort = converter.convertInputWorkflowPort(port);
+                workflowInputs.put(portId, workflowPort);
+            }
+        }
+    }
+
+    public void parseOutputs() {
+        Set<PortDetail> cwlOutputs = cwlParser.parseOutputs();
+        for(PortDetail port: cwlOutputs) {
+            String portId = port.getId();
+            OutputWorkflowPort workflowPort = converter.convertOutputWorkflowPort(port);
+            workflowOutputs.put(portId, workflowPort);
+        }
+    }
+
+    public void parseProcessors(Set<Step> cwlSteps) {
+        for(Step step: cwlSteps) {
+            Processor processor = converter.convertStepToProcessor(step);
+            workflowProcessors.put(step.getId(), processor);
+
+            DataLink datalink = new DataLink();
+            for(StepInput stepInput: step.getInputs()) {
+                InputProcessorPort processorPort = new InputProcessorPort(processor, stepInput.getId());
+                processorInputs.put(stepInput.getId(), processorPort);
+            }
+            for(StepOutput stepOutput: step.getOutputs()) {
+                OutputProcessorPort processorPort = new OutputProcessorPort(processor, stepOutput.getId());
+                processorOutputs.put(stepOutput.getId(), processorPort);
+            }
+        }
+    }
+
+    public void parseDataLinks(Set<Step> cwlSteps) {
+        for(Step step: cwlSteps) {
+            for(StepInput stepInput: step.getInputs()) {
+                String[] sourcePath = stepInput.getSource().split("/");
+                String source = sourcePath[sourcePath.length-1];
+                source = source.replace("#", "");
+
+                DataLink dataLink = new DataLink();
+                SenderPort sender = workflowInputs.get(source);
+                if(sender == null) {
+                    sender = processorOutputs.get(source);
+                }
+                if(sender == null) {
+                    throw new NullPointerException("Cannot find sender port with name: " + source);
+                }
+                String receiverId = stepInput.getId();
+                ReceiverPort receiver = workflowOutputs.get(receiverId);
+                if(receiver == null) {
+                    receiver = processorInputs.get(receiverId);
+                }
+                if(receiver == null) {
+                    throw new NullPointerException("Cannot find receiver port with name: " + receiverId);
+                }
+                dataLink.setSendsTo(receiver);
+                dataLink.setReceivesFrom(sender);
+                dataLinks.add(dataLink);
+            }
+        }
+    }
+
+    public Map<String, InputWorkflowPort> getWorkflowInputs() {
+        return workflowInputs;
+    }
+
+    public void setWorkflowInputs(Map<String, InputWorkflowPort> workflowInputs) {
+        this.workflowInputs = workflowInputs;
+    }
+
+    public Map<String, OutputWorkflowPort> getWorkflowOutputs() {
+        return workflowOutputs;
+    }
+
+    public void setWorkflowOutputs(Map<String, OutputWorkflowPort> workflowOutputs) {
+        this.workflowOutputs = workflowOutputs;
+    }
+
+    public Map<String, Processor> getWorkflowProcessors() {
+        return workflowProcessors;
+    }
+
+    public void setWorkflowProcessors(Map<String, Processor> workflowProcessors) {
+        this.workflowProcessors = workflowProcessors;
+    }
+
+    public Map<String, InputProcessorPort> getProcessorInputs() {
+        return processorInputs;
+    }
+
+    public void setProcessorInputs(Map<String, InputProcessorPort> processorInputs) {
+        this.processorInputs = processorInputs;
+    }
+
+    public Map<String, OutputProcessorPort> getProcessorOutputs() {
+        return processorOutputs;
+    }
+
+    public void setProcessorOutputs(Map<String, OutputProcessorPort> processorOutputs) {
+        this.processorOutputs = processorOutputs;
+    }
+
+    public Set<DataLink> getDataLinks() {
+        return dataLinks;
+    }
+
+    public void setDataLinks(Set<DataLink> dataLinks) {
+        this.dataLinks = dataLinks;
+    }
+}

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/WorkflowParser.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/WorkflowParser.java
@@ -18,8 +18,12 @@
  */
 package org.apache.taverna.scufl2.cwl;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.HashSet;
 
 import java.lang.NullPointerException;
 

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/YAMLHelper.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/YAMLHelper.java
@@ -1,0 +1,484 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.taverna.scufl2.cwl;
+
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+public class YAMLHelper {
+
+    public static final String ARRAY_SPLIT_BRACKETS = "\\[\\]";
+    public static final String ARRAY_SIGNATURE_BRACKETS = "\\[\\]$";
+    private static final String INPUTS = "inputs";
+    private static final String OUTPUTS = "outputs";
+    private static final String STEPS = "steps";
+    private static final String ID = "id";
+    private static final String TYPE = "type";
+    private static final String ARRAY = "array";
+    private static final String DESCRIPTION = "description";
+    private static final int DEPTH_0 = 0;
+    private static final int DEPTH_1 = 1;
+    private static final int DEPTH_2 = 2;
+
+    private static final String FLOAT = "float";
+    private static final String NULL = "null";
+    private static final String BOOLEAN = "boolean";
+    private static final String INT = "int";
+    private static final String DOUBLE = "double";
+    private static final String STRING = "string";
+    private static final String LABEL = "label";
+    private static final String FILE = "file";
+    private static final String DIRECTORY = "directory";
+    private static final String FORMAT = "format";
+    private static final String RUN = "run";
+    private static final String SOURCE = "source";
+
+    private JsonNode nameSpace;
+
+    public YAMLHelper() {
+        this.nameSpace = null;
+    }
+
+    public JsonNode getNameSpace() {
+        return nameSpace;
+    }
+
+    /**
+     * This method is processing the CWL NameSpace for later use such as
+     * figuring out the Format of a input or output
+     */
+    public void processNameSpace(JsonNode file) {
+
+        if (file != null && file.has("$namespaces")) {
+            nameSpace = file.path("$namespaces");
+        }
+
+    }
+
+    public Map<String, Integer> processInputDepths(JsonNode file) {
+        return process(file.get(INPUTS));
+    }
+
+    public Map<String, Integer> processOutputDepths(JsonNode file) {
+        return process(file.get(OUTPUTS));
+    }
+
+    public Map<String, PortDetail> processInputDetails(JsonNode file) {
+        return processdetails(file.get(INPUTS));
+    }
+
+    public Map<String, PortDetail> processOutputDetails(JsonNode file) {
+        return processdetails(file.get(OUTPUTS));
+    }
+
+    /**
+     *
+     */
+    public Set<Step> processSteps(JsonNode file) {
+        Set<Step> result = new HashSet<>();
+
+        if(file == null) {
+            return result;
+        }
+
+        if(file.has(STEPS)) {
+            JsonNode steps = file.get(STEPS);
+            if(steps.isArray()) {
+                for (JsonNode stepNode : steps) {
+                    Step step = new Step();
+                    String id = stepNode.get(ID).asText();
+
+                    String run = stepNode.get(RUN).asText();
+                    Set<StepInput> inputs = processStepInput(stepNode.get(INPUTS));
+                    step.setId(id);
+                    step.setRun(run);
+                    step.setInputs(inputs);
+                    result.add(step);
+                }
+            } else if(steps.isObject()) {
+                Iterator<Entry<String, JsonNode>> iterator = steps.fields();
+                while(iterator.hasNext()) {
+                    Entry<String, JsonNode> entry = iterator.next();
+                    Step step = new Step();
+
+                    String id = entry.getKey();
+                    JsonNode value = entry.getValue();
+                    if(value.has(RUN)) {
+                        String run = entry.getValue().get(RUN).asText();
+                        step.setRun(run);
+                    }
+                    Set<StepInput> inputs = processStepInput(value.get(INPUTS));
+                    step.setId(id);
+                    step.setInputs(inputs);
+
+                    result.add(step);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private Set<StepInput> processStepInput(JsonNode inputs) {
+
+        Set<StepInput> result = new HashSet<>();
+        if(inputs == null) {
+            return result;
+        }
+        if (inputs.getClass() == ArrayNode.class) {
+
+            for (JsonNode input : inputs) {
+                String id = input.get(ID).asText();
+                String source = input.get(SOURCE).asText();
+
+                result.add(new StepInput(id, source));
+            }
+        } else if (inputs.getClass() == ObjectNode.class) {
+            Iterator<Entry<String, JsonNode>> iterator = inputs.fields();
+            while (iterator.hasNext()) {
+                Entry<String, JsonNode> entry = iterator.next();
+
+                String id = entry.getKey();
+                String source = entry.getValue().get(SOURCE).asText();
+
+                result.add(new StepInput(id, source));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * This method will go through CWL tool input or out puts and figure outs
+     * their IDs and the respective depths
+     *
+     * @param inputs
+     *            This is JsonNode object which contains the Inputs or outputs
+     *            of the respective CWL tool
+     * @return This the respective, ID and the depth of the input or output
+     */
+    public Map<String, Integer> process(JsonNode inputs) {
+
+        Map<String, Integer> result = new HashMap<>();
+
+        if (inputs == null)
+            return result;
+
+        if (inputs.getClass() == ArrayNode.class) {
+            Iterator<JsonNode> iterator = inputs.iterator();
+
+            while (iterator.hasNext()) {
+                JsonNode input = iterator.next();
+                String currentInputId = input.get(ID).asText();
+
+                JsonNode typeConfigurations;
+                try {
+
+                    typeConfigurations = input.get(TYPE);
+                    // if type :single argument
+                    if (typeConfigurations.getClass() == TextNode.class) {
+                        // inputs:
+                        /// -id: input_1
+                        //// type: int[]
+                        if (isValidArrayType(typeConfigurations.asText()))
+                            result.put(currentInputId, DEPTH_1);
+                            // inputs:
+                            /// -id: input_1
+                            //// type: int or int?
+                        else
+                            result.put(currentInputId, DEPTH_0);
+                        // type : defined as another map which contains type:
+                    } else if (typeConfigurations.getClass() == ObjectNode.class) {
+                        // inputs:
+                        /// -id: input_1
+                        //// type:
+                        ///// type: array or int[]
+                        String inputType = typeConfigurations.get(TYPE).asText();
+                        if (inputType.equals(ARRAY) || isValidArrayType(inputType)) {
+                            result.put(currentInputId, DEPTH_1);
+
+                        }
+                        // inputs:
+                        // -id: input_1
+                        // type:
+                        // type: ["null",int]
+                    } else if (typeConfigurations.getClass() == ArrayNode.class) {
+                        if (isValidDataType(typeConfigurations)) {
+                            result.put(currentInputId, DEPTH_0);
+                        }
+
+                    }
+
+                } catch (ClassCastException e) {
+
+                    System.out.println("Class cast exception !!!");
+                }
+
+            }
+        } else if (inputs.getClass() == ObjectNode.class) {
+
+            Iterator<Entry<String, JsonNode>> iterator = inputs.fields();
+
+            while (iterator.hasNext()) {
+                Entry<String, JsonNode> entry = iterator.next();
+                String currentInputId = entry.getKey();
+                JsonNode typeConfigurations = entry.getValue();
+
+                if (typeConfigurations.getClass() == TextNode.class) {
+                    if (typeConfigurations.asText().startsWith("$")) {
+                        System.out.println("Exception");
+                    }
+                    // inputs:
+                    /// input_1: int[]
+                    else if (isValidArrayType(typeConfigurations.asText()))
+                        result.put(currentInputId, DEPTH_1);
+                        // inputs:
+                        /// input_1: int or int?
+                    else
+                        result.put(currentInputId, DEPTH_0);
+
+                } else if (typeConfigurations.getClass() == ObjectNode.class) {
+
+                    if (typeConfigurations.has(TYPE)) {
+                        JsonNode inputType = typeConfigurations.get(TYPE);
+                        // inputs:
+                        /// input_1:
+                        //// type: [int,"null"]
+                        if (inputType.getClass() == ArrayNode.class) {
+                            if (isValidDataType(inputType))
+                                result.put(currentInputId, DEPTH_0);
+                        } else {
+                            // inputs:
+                            /// input_1:
+                            //// type: array or int[]
+                            if (inputType.asText().equals(ARRAY) || isValidArrayType(inputType.asText()))
+                                result.put(currentInputId, DEPTH_1);
+                                // inputs:
+                                /// input_1:
+                                //// type: int or int?
+                            else
+                                result.put(currentInputId, DEPTH_0);
+                        }
+                    }
+                }
+            }
+
+        }
+        return result;
+    }
+
+    /**
+     * This method is used for extracting details of the CWL tool inputs or
+     * outputs. ex:Label, Format, Description
+     *
+     * @param inputs
+     *            This is JsonNode object which contains the Inputs or outputs
+     *            of the respective CWL tool
+     * @return
+     */
+    private Map<String, PortDetail> processdetails(JsonNode inputs) {
+
+        Map<String, PortDetail> result = new HashMap<>();
+        if(inputs == null) {
+            return result;
+        }
+        if (inputs.getClass() == ArrayNode.class) {
+
+            for (JsonNode input : inputs) {
+                PortDetail detail = new PortDetail();
+                String currentInputId = input.get(ID).asText();
+
+                getParamDetails(result, input, detail, currentInputId);
+
+            }
+        } else if (inputs.getClass() == ObjectNode.class) {
+            Iterator<Entry<String, JsonNode>> iterator = inputs.fields();
+            while (iterator.hasNext()) {
+                PortDetail detail = new PortDetail();
+                Entry<String, JsonNode> entry = iterator.next();
+                getParamDetails(result, entry.getValue(), detail, entry.getKey());
+            }
+        }
+        return result;
+    }
+
+    private void getParamDetails(Map<String, PortDetail> result, JsonNode input, PortDetail detail,
+                                 String currentInputId) {
+        extractDescription(input, detail);
+
+        extractFormat(input, detail);
+
+        extractLabel(input, detail);
+
+        result.put(currentInputId, detail);
+    }
+
+    /**
+     * This method is used for extracting the Label of a CWL input or Output
+     *
+     * @param input
+     *            Single CWL input or output as a JsonNode
+     * @param detail
+     *            respective PortDetail Object to hold the extracted Label
+     */
+    public void extractLabel(JsonNode input, PortDetail detail) {
+        if (input != null)
+            if (input.has(LABEL)) {
+                detail.setLabel(input.get(LABEL).asText());
+            } else {
+                detail.setLabel(null);
+            }
+    }
+
+    /**
+     *
+     * @param input
+     *            Single CWL input or output as a JsonNode
+     * @param detail
+     *            respective PortDetail Object to hold the extracted Label
+     */
+    public void extractDescription(JsonNode input, PortDetail detail) {
+        if (input != null)
+            if (input.has(DESCRIPTION)) {
+                detail.setDescription(input.get(DESCRIPTION).asText());
+            } else {
+                detail.setDescription(null);
+            }
+    }
+
+    /**
+     * This method is used for extracting the Formats of a CWL input or Output
+     * Single argument(Input or Output) can have multiple Formats.
+     *
+     * @param input
+     *            Single CWL input or output as a JsonNode
+     * @param detail
+     *            respective PortDetail Object to hold the extracted Label
+     */
+    public void extractFormat(JsonNode input, PortDetail detail) {
+        if (input != null)
+            if (input.has(FORMAT)) {
+
+                JsonNode formatInfo = input.get(FORMAT);
+
+                ArrayList<String> format = new ArrayList<>();
+                detail.setFormat(format);
+
+                if (formatInfo.getClass() == TextNode.class) {
+
+                    figureOutFormats(formatInfo.asText(), detail);
+                } else if (formatInfo.getClass() == ArrayNode.class) {
+                    for (JsonNode eachFormat : formatInfo) {
+                        figureOutFormats(eachFormat.asText(), detail);
+                    }
+                }
+
+            }
+    }
+
+    /**
+     * Re Format the CWL format using the NameSpace in CWL Tool if possible
+     * otherwise it doesn't change the current nameSpace => edam:http://edam.org
+     * format : edam :1245 => http://edamontology.org/1245
+     *
+     * @param formatInfoString
+     *            Single Format
+     * @param detail
+     *            respective PortDetail Object to hold the extracted Label
+     */
+    public void figureOutFormats(String formatInfoString, PortDetail detail) {
+        if (formatInfoString.startsWith("$")) {
+
+            detail.addFormat(formatInfoString);
+        } else if (formatInfoString.contains(":")) {
+            String format[] = formatInfoString.split(":");
+            String namespaceKey = format[0];
+            String urlAppednd = format[1];
+
+            if (nameSpace.has(namespaceKey))
+                detail.addFormat(nameSpace.get(namespaceKey).asText() + urlAppednd);
+            else
+                // can't figure out the format
+                detail.addFormat(formatInfoString);
+
+        } else {
+            // can't figure out the format
+            detail.addFormat(formatInfoString);
+        }
+    }
+
+    /**
+     * This method is used to check whether the input/output is valid CWL TYPE
+     * when the type is represented as type: ["null","int"]
+     *
+     * @param typeConfigurations
+     *            Type of the CWl input or output
+     * @return
+     */
+    public boolean isValidDataType(JsonNode typeConfigurations) {
+        if (typeConfigurations == null)
+            return false;
+        for (JsonNode type : typeConfigurations) {
+            if (!(type.asText().equals(FLOAT) || type.asText().equals(NULL) || type.asText().equals(BOOLEAN)
+                    || type.asText().equals(INT) || type.asText().equals(STRING) || type.asText().equals(DOUBLE)
+                    || type.asText().equals(FILE)||type.asText().equals(DIRECTORY)))
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     *
+     * This method is for figure out whether the parameter is an array or not.
+     * As from CWL document v1.0, array can be defined as "TYPE[]". For Example
+     * : int[] This method will look for "[]" sequence of characters in the end
+     * of the type and is provided type is a valid CWL TYPE or not
+     *
+     * @param type
+     *            type of the CWL parameter
+     * @return
+     */
+    public boolean isValidArrayType(String type) {
+        if (type == null)
+            return false;
+        Pattern pattern = Pattern.compile(ARRAY_SIGNATURE_BRACKETS);
+        Matcher matcher = pattern.matcher(type);
+        ObjectMapper mapper = new ObjectMapper();
+        ArrayNode node = mapper.createArrayNode();
+        node.add(type.split(ARRAY_SPLIT_BRACKETS)[0]);
+        if (matcher.find() && isValidDataType(node))
+            return true;
+        else
+            return false;
+    }
+}

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/PortDetail.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/PortDetail.java
@@ -25,11 +25,21 @@ import java.util.ArrayList;
 public class PortDetail {
 
 
-    private String label;
 
+    private String id;
+    private String label;
     private int depth;
     private String description;
     private ArrayList<String> format;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public int getDepth() {
         return depth;
     }

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/PortDetail.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/PortDetail.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.taverna.scufl2.cwl;
+
+
+import java.util.ArrayList;
+
+public class PortDetail {
+
+
+    private String label;
+
+    private int depth;
+    private String description;
+    private ArrayList<String> format;
+    public int getDepth() {
+        return depth;
+    }
+    public void setDepth(int depth) {
+        this.depth = depth;
+    }
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    public String getLabel() {
+        return label;
+    }
+    public void setLabel(String label) {
+        this.label = label;
+    }
+    public ArrayList<String> getFormat() {
+        return format;
+    }
+    public void setFormat(ArrayList<String> format) {
+        this.format = format;
+    }
+
+    public void addFormat(String format){
+        this.format.add(format);
+    }
+
+}

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/Step.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/Step.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.taverna.scufl2.cwl;
+
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
+
+public class Step {
+
+
+    private String id;
+    private String run;
+
+    private Set<StepInput> inputs;
+    private Set<StepOutput> outputs;
+
+    public Step() {
+        inputs = new HashSet<>();
+        outputs = new HashSet<>();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getRun() {
+        return run;
+    }
+
+    public void setRun(String run) {
+        this.run = run;
+    }
+
+    public void addInput(String id, String source) {
+        inputs.add(new StepInput(id, source));
+    }
+
+    public void setInputs(Set<StepInput> inputs) {
+        this.inputs = inputs;
+    }
+
+    public Set<StepInput> getInputs() {
+        return inputs;
+    }
+
+    public void addOutput(String id) {
+        outputs.add(new StepOutput(id));
+    }
+
+    public void setOutputs(Set<StepOutput> outputs) {
+        this.outputs = outputs;
+    }
+
+    public Set<StepOutput> getOutputs() {
+        return outputs;
+    }
+
+    public String toString() {
+        return "Step " + id + ": run = " + run;
+    }
+
+}

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/StepInput.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/StepInput.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.taverna.scufl2.cwl;
+
+import java.util.*;
+
+public class StepInput {
+
+    private String id;
+    private String source;
+
+    public StepInput() {
+        this.id = null;
+        this.source = null;
+    }
+
+    public StepInput(String id, String source) {
+        this.id = id;
+        this.source = source;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getSource() {
+        return source;
+    }
+}

--- a/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/StepOutput.java
+++ b/taverna-scufl2-cwl/src/main/java/org/apache/taverna/scufl2/cwl/components/StepOutput.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.taverna.scufl2.cwl;
+
+public class StepOutput {
+
+    private String id;
+
+    public StepOutput() {
+        this.id = null;
+    }
+
+    public StepOutput(String id) {
+        this.id = id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
+++ b/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
@@ -1,84 +1,53 @@
 package org.apache.taverna.scufl2.cwl;
 
-import java.io.*;
-import java.util.ArrayList;
+
+import java.util.*;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import org.apache.commons.io.FileUtils;
 
-import org.apache.taverna.scufl2.cwl.Parser;
-import org.apache.taverna.scufl2.cwl.InputField;
+import org.yaml.snakeyaml.Yaml;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import org.apache.taverna.scufl2.api.port.InputWorkflowPort;
+import org.apache.taverna.scufl2.api.port.OutputWorkflowPort;
+
 
 public class TestParser {
-
     private static final String SIMPLE_STRING_INPUT = "/simple_string_input.cwl";
     private static final String INT_INPUT = "/int_input.cwl";
 
-    @Test
-    public void testGetDepth() throws Exception {
-
-        assert Parser.getDepth("  test") == 1;
-        assert Parser.getDepth("test") == 0;
-        assert Parser.getDepth("    test") == 2;
-    }
+    private static JsonNode cwlFile;
 
     @Test
-    public void testGetKey() throws Exception {
+    public void testStringInput() throws Exception {
 
-        assert Parser.getKeyFromLine("  test: test_value").equals("test");
-        assert Parser.getKeyFromLine("test: 1 ").equals("test");
-        assert Parser.getKeyFromLine("    test:").equals("test");
-    }
+        Yaml reader = new Yaml();
+        ObjectMapper mapper = new ObjectMapper();
+        cwlFile = mapper.valueToTree(reader.load(TestParser.class.getResourceAsStream(SIMPLE_STRING_INPUT)));
+        System.out.println(cwlFile);
+        Parser parser = new Parser(cwlFile);
 
-    @Test
-    public void testGetValue() throws Exception {
-
-        assert Parser.getValueFromLine("  test: test_value").equals("test_value");
-        assert Parser.getValueFromLine("test: 1 ").equals("1");
-        assert Parser.getValueFromLine("    test:").equals("");
-    }
-
-    @Test
-    public void testSimpleInput() throws Exception {
-        File yaml = FileUtils.getFile("src", "test", "resources", SIMPLE_STRING_INPUT);
-
-        Parser parser = new Parser(yaml);
-
-        ArrayList<InputField> inputs = parser.parseInputs();
-
-        assertEquals(1, inputs.size());
-        assertEquals("example_string", inputs.get(0).key);
-    }
-
-    @Test
-    public void testIntInput() throws Exception {
-        File yaml = FileUtils.getFile("src", "test", "resources", INT_INPUT);
-
-        Parser parser = new Parser(yaml);
-
-        ArrayList<InputField> inputs = parser.parseInputs();
-
-        assertEquals(1, inputs.size());
-        assertEquals("example_int", inputs.get(0).key);
-        assertEquals("int", inputs.get(0).type);
-        assertEquals(2, inputs.get(0).position);
-        assertEquals("-i", inputs.get(0).prefix);
-    }
-
-    void printFile(File yaml) throws Exception {
-        /**
-         * Print file
-         */
-        FileReader fdesc = new FileReader(yaml);
-        BufferedReader bufferedReader = new BufferedReader(fdesc);
-        String yamlLine;
-        while((yamlLine = bufferedReader.readLine()) != null) {
-            System.out.println(yamlLine);
+        Set<InputWorkflowPort> result = parser.parseInputs();
+        for(InputWorkflowPort port: result) {
+            System.out.println(port.getName());
         }
+        ArrayList<InputWorkflowPort> inputs = new ArrayList<>(result);
+        assertEquals(inputs.get(0).getName(), "example_string");
 
-        System.out.println("*************************");
-        bufferedReader.close();
-        /*****/
+        Set<OutputWorkflowPort> result2 = parser.parseOutputs();
+        for(OutputWorkflowPort port: result2) {
+            System.out.println(port.getName());
+        }
+        System.out.println("Showing steps:");
+
+        Set<Step> steps = parser.parseSteps();
+        for(Step step: steps) {
+            System.out.println(step);
+        }
     }
 }

--- a/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
+++ b/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
@@ -1,7 +1,8 @@
 package org.apache.taverna.scufl2.cwl;
 
 
-import java.util.*;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
+++ b/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.taverna.scufl2.cwl;
 
 
@@ -48,9 +66,12 @@ public class TestParser {
     @Test
     public void testParseInputs() throws Exception {
 
+        workflow.setParent(null);
         NamedSet<InputWorkflowPort> workflowInputs = workflow.getInputPorts();
-        NamedSet<InputWorkflowPort> expectedInputs = new NamedSet<>();
-        expectedInputs.add(new InputWorkflowPort(workflow, "name"));
+
+        Workflow expectedWorkflow = new Workflow(workflow.getName());
+        NamedSet<InputWorkflowPort> expectedInputs = expectedWorkflow.getInputPorts();
+        expectedInputs.add(new InputWorkflowPort(expectedWorkflow, "name"));
 
         assertEquals(expectedInputs, workflowInputs);
     }
@@ -67,9 +88,12 @@ public class TestParser {
     @Test
     public void testParseProcessors() throws Exception {
 
+        workflow.setParent(null);
         NamedSet<Processor> workflowProcessors = workflow.getProcessors();
-        NamedSet<Processor> expectedProcessors = new NamedSet<>();
-        expectedProcessors.add(new Processor(workflow, "step1"));
+
+        Workflow expectedWorkflow = new Workflow(workflow.getName());
+        NamedSet<Processor> expectedProcessors = expectedWorkflow.getProcessors();
+        expectedProcessors.add(new Processor(expectedWorkflow, "step1"));
 
         assertEquals(expectedProcessors, workflowProcessors);
     }
@@ -79,10 +103,9 @@ public class TestParser {
 
         Set<DataLink> workflowDataLinks = workflow.getDataLinks();
         Set<DataLink> expectedDataLinks = new HashSet<>();
-        Set<Processor> processorSet = workflow.getProcessors();
+        NamedSet<Processor> processorSet = workflow.getProcessors();
         // processorSet has one processor
-        Processor processor = processorSet.iterator().next();
-
+        Processor processor = processorSet.getByName("step1");
         expectedDataLinks.add(
                 new DataLink(
                         workflow,
@@ -91,6 +114,7 @@ public class TestParser {
                 )
         );
 
+        assertEquals(1, workflowDataLinks.size());
         assertEquals(expectedDataLinks, workflowDataLinks);
     }
 }

--- a/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
+++ b/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
@@ -3,6 +3,7 @@ package org.apache.taverna.scufl2.cwl;
 
 import java.util.*;
 
+import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
@@ -13,41 +14,82 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+import org.apache.taverna.scufl2.api.core.Workflow;
+import org.apache.taverna.scufl2.api.core.Processor;
+import org.apache.taverna.scufl2.api.core.DataLink;
+
+import org.apache.taverna.scufl2.api.common.NamedSet;
+
 import org.apache.taverna.scufl2.api.port.InputWorkflowPort;
 import org.apache.taverna.scufl2.api.port.OutputWorkflowPort;
+import org.apache.taverna.scufl2.api.port.InputProcessorPort;
 
 
 public class TestParser {
-    private static final String SIMPLE_STRING_INPUT = "/simple_string_input.cwl";
-    private static final String INT_INPUT = "/int_input.cwl";
+    private static final String HELLO_WORLD_CWL = "/hello_world.cwl";
 
     private static JsonNode cwlFile;
+    private WorkflowParser parser;
+    private Workflow workflow;
 
-    @Test
-    public void testStringInput() throws Exception {
+    @Before
+    public void initialize() {
 
         Yaml reader = new Yaml();
         ObjectMapper mapper = new ObjectMapper();
-        cwlFile = mapper.valueToTree(reader.load(TestParser.class.getResourceAsStream(SIMPLE_STRING_INPUT)));
+        cwlFile = mapper.valueToTree(reader.load(TestParser.class.getResourceAsStream(HELLO_WORLD_CWL)));
         System.out.println(cwlFile);
-        Parser parser = new Parser(cwlFile);
+        this.parser = new WorkflowParser(cwlFile);
 
-        Set<InputWorkflowPort> result = parser.parseInputs();
-        for(InputWorkflowPort port: result) {
-            System.out.println(port.getName());
-        }
-        ArrayList<InputWorkflowPort> inputs = new ArrayList<>(result);
-        assertEquals(inputs.get(0).getName(), "example_string");
+        this.workflow = parser.buildWorkflow();
+    }
 
-        Set<OutputWorkflowPort> result2 = parser.parseOutputs();
-        for(OutputWorkflowPort port: result2) {
-            System.out.println(port.getName());
-        }
-        System.out.println("Showing steps:");
+    @Test
+    public void testParseInputs() throws Exception {
 
-        Set<Step> steps = parser.parseSteps();
-        for(Step step: steps) {
-            System.out.println(step);
-        }
+        NamedSet<InputWorkflowPort> workflowInputs = workflow.getInputPorts();
+        NamedSet<InputWorkflowPort> expectedInputs = new NamedSet<>();
+        expectedInputs.add(new InputWorkflowPort(workflow, "name"));
+
+        assertEquals(expectedInputs, workflowInputs);
+    }
+
+    @Test
+    public void testParseOutputs() throws Exception {
+
+        NamedSet<OutputWorkflowPort> workflowOutputs = workflow.getOutputPorts();
+        NamedSet<OutputWorkflowPort> expectedOutputs = new NamedSet<>();
+
+        assertEquals(expectedOutputs, workflowOutputs);
+    }
+
+    @Test
+    public void testParseProcessors() throws Exception {
+
+        NamedSet<Processor> workflowProcessors = workflow.getProcessors();
+        NamedSet<Processor> expectedProcessors = new NamedSet<>();
+        expectedProcessors.add(new Processor(workflow, "step1"));
+
+        assertEquals(expectedProcessors, workflowProcessors);
+    }
+
+    @Test
+    public void testParseDataLinks() throws Exception {
+
+        Set<DataLink> workflowDataLinks = workflow.getDataLinks();
+        Set<DataLink> expectedDataLinks = new HashSet<>();
+        Set<Processor> processorSet = workflow.getProcessors();
+        // processorSet has one processor
+        Processor processor = processorSet.iterator().next();
+
+        expectedDataLinks.add(
+                new DataLink(
+                        workflow,
+                        new InputWorkflowPort(workflow, "name"),
+                        new InputProcessorPort(processor, "text")
+                )
+        );
+
+        assertEquals(expectedDataLinks, workflowDataLinks);
     }
 }

--- a/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
+++ b/taverna-scufl2-cwl/src/test/java/org/apache/taverna/scufl2/cwl/TestParser.java
@@ -1,0 +1,84 @@
+package org.apache.taverna.scufl2.cwl;
+
+import java.io.*;
+import java.util.ArrayList;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.apache.commons.io.FileUtils;
+
+import org.apache.taverna.scufl2.cwl.Parser;
+import org.apache.taverna.scufl2.cwl.InputField;
+
+public class TestParser {
+
+    private static final String SIMPLE_STRING_INPUT = "/simple_string_input.cwl";
+    private static final String INT_INPUT = "/int_input.cwl";
+
+    @Test
+    public void testGetDepth() throws Exception {
+
+        assert Parser.getDepth("  test") == 1;
+        assert Parser.getDepth("test") == 0;
+        assert Parser.getDepth("    test") == 2;
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+
+        assert Parser.getKeyFromLine("  test: test_value").equals("test");
+        assert Parser.getKeyFromLine("test: 1 ").equals("test");
+        assert Parser.getKeyFromLine("    test:").equals("test");
+    }
+
+    @Test
+    public void testGetValue() throws Exception {
+
+        assert Parser.getValueFromLine("  test: test_value").equals("test_value");
+        assert Parser.getValueFromLine("test: 1 ").equals("1");
+        assert Parser.getValueFromLine("    test:").equals("");
+    }
+
+    @Test
+    public void testSimpleInput() throws Exception {
+        File yaml = FileUtils.getFile("src", "test", "resources", SIMPLE_STRING_INPUT);
+
+        Parser parser = new Parser(yaml);
+
+        ArrayList<InputField> inputs = parser.parseInputs();
+
+        assertEquals(1, inputs.size());
+        assertEquals("example_string", inputs.get(0).key);
+    }
+
+    @Test
+    public void testIntInput() throws Exception {
+        File yaml = FileUtils.getFile("src", "test", "resources", INT_INPUT);
+
+        Parser parser = new Parser(yaml);
+
+        ArrayList<InputField> inputs = parser.parseInputs();
+
+        assertEquals(1, inputs.size());
+        assertEquals("example_int", inputs.get(0).key);
+        assertEquals("int", inputs.get(0).type);
+        assertEquals(2, inputs.get(0).position);
+        assertEquals("-i", inputs.get(0).prefix);
+    }
+
+    void printFile(File yaml) throws Exception {
+        /**
+         * Print file
+         */
+        FileReader fdesc = new FileReader(yaml);
+        BufferedReader bufferedReader = new BufferedReader(fdesc);
+        String yamlLine;
+        while((yamlLine = bufferedReader.readLine()) != null) {
+            System.out.println(yamlLine);
+        }
+
+        System.out.println("*************************");
+        bufferedReader.close();
+        /*****/
+    }
+}

--- a/taverna-scufl2-cwl/src/test/resources/1st-tool.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/1st-tool.cwl
@@ -1,0 +1,10 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  message:
+    type: string
+
+    inputBinding:
+      position: 1
+outputs: []

--- a/taverna-scufl2-cwl/src/test/resources/1st-tool.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/1st-tool.cwl
@@ -1,3 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements. See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership. The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
 cwlVersion: v1.0
 class: CommandLineTool
 baseCommand: echo

--- a/taverna-scufl2-cwl/src/test/resources/hello_world.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/hello_world.cwl
@@ -1,0 +1,18 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  name: string
+
+outputs: []
+
+steps:
+  step1:
+    run: example.cwl
+
+    inputs:
+      - id: text
+        source: "#x/name"
+
+    outputs: []

--- a/taverna-scufl2-cwl/src/test/resources/hello_world.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/hello_world.cwl
@@ -1,4 +1,22 @@
 #!/usr/bin/env cwl-runner
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements. See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership. The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
 cwlVersion: v1.0
 class: Workflow
 

--- a/taverna-scufl2-cwl/src/test/resources/int_input.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/int_input.cwl
@@ -1,0 +1,6 @@
+inputs:
+  example_int:
+    type: int
+    inputBinding:
+      position: 2
+      prefix: -i

--- a/taverna-scufl2-cwl/src/test/resources/int_input.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/int_input.cwl
@@ -1,3 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements. See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership. The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
 inputs:
   example_int:
     type: int

--- a/taverna-scufl2-cwl/src/test/resources/simple_string_input.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/simple_string_input.cwl
@@ -1,3 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements. See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership. The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
 inputs:
   example_string: string
 steps:

--- a/taverna-scufl2-cwl/src/test/resources/simple_string_input.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/simple_string_input.cwl
@@ -1,2 +1,5 @@
 inputs:
   example_string: string
+steps:
+  step1:
+    run: run1

--- a/taverna-scufl2-cwl/src/test/resources/simple_string_input.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/simple_string_input.cwl
@@ -1,0 +1,2 @@
+inputs:
+  example_string: string

--- a/taverna-scufl2-cwl/src/test/resources/worklflow2.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/worklflow2.cwl
@@ -1,4 +1,21 @@
 #!/usr/bin/env cwl-runner
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements. See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership. The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
 cwlVersion: v1.0
 class: Workflow
 

--- a/taverna-scufl2-cwl/src/test/resources/worklflow2.cwl
+++ b/taverna-scufl2-cwl/src/test/resources/worklflow2.cwl
@@ -1,0 +1,27 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  message: string
+
+outputs:
+  download:
+    type: File
+    outputSource:  "#step1/curl"
+
+steps:
+  step1:
+    run:
+      class: CommandLineTool
+      baseCommand: echo
+      inputs:
+        text:
+          type: string
+          inputBinding:
+            position: 1
+      outputs: []
+    in:
+      text: message
+
+    out: [curl]


### PR DESCRIPTION
This is a pull request that adds structural import for a CWL workflow to Apache Taverna.
The current code parses the cwl file to extract inputs, outputs and steps of a workflow, and then converts them to a Taverna workflow containing ports, processors and data links.

In the tests, we try to compare expected objects (like InputWorkflowPort) with the newly created workflow from the cwl file. We do this by using the default equality of Taverna components (Implemented inside AbstractNamed class) but this way we try to compare the name and the parent of two objects. 
Currently, we set the parent of the expected object to be the same as the parent of the created object, but this will modify the parent as well to point to the same object in the end and thus we'll have two equal objects all the time. 
What we can do is set objects' parents to null before comparing and in that way we will compare the names and not the parents.

Is there another approach or is the current one correct?